### PR TITLE
Adding support for the tsv files 

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -10,21 +10,22 @@ from ckan.model.types import make_uuid
 import logging
 logger = logging.getLogger()
 
+
 class Webstorer(CkanCommand):
     """
     Upload all available resources to the webstore
 
     Usage:
 
-        paster datastorer update 
-           - Archive all resources or just those belonging to a specific package 
-             if a package id is provided
+        paster datastorer update
+           - Archive all resources or just those belonging to a specific
+             package if a package id is provided
 
-    """    
+    """
     summary = __doc__.split('\n')[0]
     usage = __doc__
-    min_args = 1 
-    max_args = 1 
+    min_args = 1
+    max_args = 1
 
     def command(self):
         """
@@ -39,7 +40,8 @@ class Webstorer(CkanCommand):
         #import after load config so CKAN_CONFIG evironment variable can be set
         from ckan.lib.celery_app import celery
         import tasks
-        user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
+        user = get_action('get_site_user')({'model': model,
+                                            'ignore_auth': True}, {})
         context = json.dumps({
             'site_url': config['ckan.site_url'],
             'apikey': user.get('apikey'),
@@ -49,22 +51,26 @@ class Webstorer(CkanCommand):
         api_url = urlparse.urljoin(config['ckan.site_url'], 'api/action')
 
         if cmd == 'update':
-            response = requests.post(api_url + '/current_package_list_with_resources', "{}")
+            response = requests.post(api_url +
+                                     '/current_package_list_with_resources',
+                                     "{}")
             packages = json.loads(response.content).get('result')
 
             for package in packages:
                 for resource in package.get('resources', []):
                     data = json.dumps(resource, {'model': model})
-                    
+
                     if resource['webstore_url']:
                         continue
                     mimetype = resource['mimetype']
-                    if mimetype and (mimetype not in tasks.DATA_FORMATS 
-                                     or resource['format'] not in tasks.DATA_FORMATS):
+                    if mimetype and (mimetype not in tasks.DATA_FORMATS
+                                     or resource['format'] not in
+                                     tasks.DATA_FORMATS):
                         continue
 
-                    logger.info('Webstoring resource from resource %s from package %s' % (
-                        resource['url'], package['name']))
+                    logger.info('Webstoring resource from resource %s from '
+                                'package %s' % (resource['url'],
+                                                package['name']))
 
                     task_id = make_uuid()
                     datastorer_task_status = {
@@ -76,15 +82,14 @@ class Webstorer(CkanCommand):
                         'last_updated': datetime.now().isoformat()
                     }
                     datastorer_task_context = {
-                        'model': model, 
+                        'model': model,
                         'user': user.get('name')
                     }
 
-                    get_action('task_status_update')(datastorer_task_context, 
+                    get_action('task_status_update')(datastorer_task_context,
                                                      datastorer_task_status)
-                    celery.send_task("datastorer.upload", 
-                                     args=[context, data], 
+                    celery.send_task("datastorer.upload",
+                                     args=[context, data],
                                      task_id=task_id)
         else:
             logger.error('Command %s not recognized' % (cmd,))
-

--- a/ckanext/datastorer/plugin.py
+++ b/ckanext/datastorer/plugin.py
@@ -1,7 +1,8 @@
 from ckan import model
 from ckan.model.types import make_uuid
-from ckan.plugins import SingletonPlugin, implements, IDomainObjectModification, \
-    IResourceUrlChange, IConfigurable
+from ckan.plugins import (SingletonPlugin, implements,
+                          IDomainObjectModification,
+                          IResourceUrlChange, IConfigurable)
 from ckan.logic import get_action
 from ckan.lib.celery_app import celery
 import ckan.lib.helpers as h
@@ -11,10 +12,12 @@ from datetime import datetime
 from logging import getLogger
 log = getLogger(__name__)
 
+
 class WebstorerPlugin(SingletonPlugin):
     """
-    Registers to be notified whenever CKAN resources are created or their URLs change,
-    and will create a new ckanext.datastorer celery task to put the resource in the webstore.
+    Registers to be notified whenever CKAN resources are created or their
+    URLs change, and will create a new ckanext.datastorer celery task to
+    put the resource in the webstore.
     """
     implements(IDomainObjectModification, inherit=True)
     implements(IResourceUrlChange)
@@ -36,7 +39,7 @@ class WebstorerPlugin(SingletonPlugin):
                                             'defer_commit': True}, {})
 
         context = json.dumps({
-            'site_url': h.url_for_static('/', qualified = True),
+            'site_url': h.url_for_static('/', qualified=True),
             'apikey': user.get('apikey'),
             'site_user_apikey': user.get('apikey'),
             'username': user.get('name'),
@@ -53,9 +56,11 @@ class WebstorerPlugin(SingletonPlugin):
             'last_updated': datetime.now().isoformat()
         }
         archiver_task_context = {
-            'model': model, 
+            'model': model,
             'user': user.get('name'),
         }
-        get_action('task_status_update')(archiver_task_context, datastorer_task_status)
-        celery.send_task("datastorer.upload", args=[context, data], task_id=task_id)
-
+        get_action('task_status_update')(archiver_task_context,
+                                         datastorer_task_status)
+        celery.send_task("datastorer.upload",
+                         args=[context, data],
+                         task_id=task_id)

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -98,7 +98,7 @@ def _datastorer_upload(context, resource):
 
     excel_types = ['xls', 'application/ms-excel', 'application/xls',
                    'application/vnd.ms-excel']
-    tsv_types = ['text/tsv', 'text/tab-separated-values']
+    tsv_types = ['tsv', 'text/tsv', 'text/tab-separated-values']
 
     result = download(context, resource, data_formats=DATA_FORMATS)
 
@@ -110,7 +110,9 @@ def _datastorer_upload(context, resource):
     if content_type in excel_types or resource['format'] in excel_types:
         table_sets = XLSTableSet.from_fileobj(f)
     else:
-        delimiter = '\t' if content_type in tsv_types else ','
+        is_tsv = (content_type in tsv_types or
+                  resource['format'] in tsv_types)
+        delimiter = '\t' if is_tsv else ','
         table_sets = CSVTableSet.from_fileobj(f, delimiter=delimiter)
 
     ##only first sheet in xls for time being

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -101,7 +101,10 @@ def _datastorer_upload(context, resource):
     tsv_types = ['text/tsv', 'text/tab-separated-values']
 
     result = download(context, resource, data_formats=DATA_FORMATS)
-    content_type = result['headers'].get('content-type', '')
+
+    content_type = result['headers'].get('content-type', '')\
+                                    .split(';', 1)[0]  # remove parameters
+
     f = open(result['saved_file'], 'rb')
 
     if content_type in excel_types or resource['format'] in excel_types:

--- a/ckanext/datastorer/tests/static/simple.tsv
+++ b/ckanext/datastorer/tests/static/simple.tsv
@@ -1,0 +1,7 @@
+date	temperature	place
+2011-01-01	1	Galway
+2011-01-02	-1	Galway
+2011-01-03	0	Galway
+2011-01-01	6	Berkeley
+2011-01-02	8	Berkeley
+2011-01-03	5	Berkeley

--- a/ckanext/datastorer/tests/static/tsv_as_txt.txt
+++ b/ckanext/datastorer/tests/static/tsv_as_txt.txt
@@ -1,0 +1,7 @@
+date	temperature	place
+2011-01-01	1	Galway
+2011-01-02	-1	Galway
+2011-01-03	0	Galway
+2011-01-01	6	Berkeley
+2011-01-02	8	Berkeley
+2011-01-03	5	Berkeley

--- a/ckanext/datastorer/tests/test_upload_basic.py
+++ b/ckanext/datastorer/tests/test_upload_basic.py
@@ -1,6 +1,6 @@
 import ckanext.datastorer.tasks as tasks
 from ckanext.archiver.tasks import LinkCheckerError
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_equal
 import os
 import json
 import subprocess
@@ -8,8 +8,6 @@ import requests
 import time
 import uuid
 import ConfigParser
-
-
 
 
 class TestUploadBasic(object):
@@ -21,26 +19,28 @@ class TestUploadBasic(object):
         config = ConfigParser.RawConfigParser({
             'proxy_host': '0.0.0.0',
         })
-        config.read(os.path.join(os.path.dirname(os.path.abspath( __file__ )), 'tests_config.cfg'))
+        config.read(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 'tests_config.cfg'))
 
-        cls.host = config.get('tests','proxy_host')
-        cls.api_key = config.get('tests','user_api_key')
+        cls.host = config.get('tests', 'proxy_host')
+        cls.api_key = config.get('tests', 'user_api_key')
 
         if not cls.api_key:
-            raise Exception('You must add a sysadmin API key to the tests configuration file')
+            raise Exception('You must add a sysadmin API key to the tests '
+                            ' configuration file')
 
-
-        static_files_server = os.path.join(os.path.dirname(__file__), "static_files_server.py")
-        cls.static_files_server = subprocess.Popen(['python', static_files_server])
+        static_files_server = os.path.join(os.path.dirname(__file__),
+                                           'static_files_server.py')
+        cls.static_files_server = subprocess.Popen(
+            ['python', static_files_server])
 
         #make sure services are running
-        for i in range(0,50):
+        for i in range(0, 50):
             time.sleep(0.1)
             response1 = requests.get('http://0.0.0.0:50001')
             if not response1:
                 continue
             return
-
 
         cls.teardown_class()
         raise Exception('services did not start!')
@@ -53,14 +53,13 @@ class TestUploadBasic(object):
 
         response = requests.post(
             'http://%s/api/action/package_create' % self.host,
-             data=json.dumps(
-                 {'name': str(uuid.uuid4()),
-                  'resources': [{u'url': u'test'}]}
-             ),
-             headers={'Authorization': self.api_key}
+            data=json.dumps(
+                {'name': str(uuid.uuid4()),
+                 'resources': [{u'url': u'test'}]}
+            ),
+            headers={'Authorization': self.api_key}
         )
         return json.loads(response.content)['result']['resources'][0]['id']
-
 
     def test_csv_file(self):
 
@@ -70,23 +69,22 @@ class TestUploadBasic(object):
 
         context = {'site_url': 'http://%s' % self.host,
                    'site_user_apikey': self.api_key,
-                   'apikey': self.api_key
-                  }
+                   'apikey': self.api_key}
 
         resource_id = self.make_resource_id()
         data['id'] = resource_id
 
         tasks.datastorer_upload(json.dumps(context), json.dumps(data))
 
-        import time; time.sleep(0.5)
+        import time
+        time.sleep(0.5)
 
         response = requests.get(
-            'http://%s/api/data/%s/_search?q=*' % (self.host,resource_id),
-             )
+            'http://%s/api/data/%s/_search?q=*' % (self.host, resource_id),
+        )
 
         response = json.loads(response.content)
-        assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
-
+        assert_equal(len(response['hits']['hits']), 6)
 
     def test_tsv_file(self):
 
@@ -96,27 +94,25 @@ class TestUploadBasic(object):
 
         context = {'site_url': 'http://%s' % self.host,
                    'site_user_apikey': self.api_key,
-                   'apikey': self.api_key
-                  }
+                   'apikey': self.api_key}
 
         resource_id = self.make_resource_id()
         data['id'] = resource_id
 
         tasks.datastorer_upload(json.dumps(context), json.dumps(data))
 
-        import time; time.sleep(1.0)
+        import time
+        time.sleep(1.0)
 
         response = requests.get(
-            'http://%s/api/data/%s/_search?q=*' % (self.host,resource_id),
-             )
+            'http://%s/api/data/%s/_search?q=*' % (self.host, resource_id))
 
         response = json.loads(response.content)
-        assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
+        assert_equal(len(response['hits']['hits']), 6)
 
         # Check the number of fields to enusre the lines have been split
         # correctly
         assert len(response['hits']['hits'][0]['_source'].keys()) == 3
-
 
     def test_tsv_file_with_incorrect_mimetype(self):
         '''Not all servers are well-behaved, and provide the wrong mime type.
@@ -132,27 +128,25 @@ class TestUploadBasic(object):
 
         context = {'site_url': 'http://%s' % self.host,
                    'site_user_apikey': self.api_key,
-                   'apikey': self.api_key
-                  }
+                   'apikey': self.api_key}
 
         resource_id = self.make_resource_id()
         data['id'] = resource_id
 
         tasks.datastorer_upload(json.dumps(context), json.dumps(data))
 
-        import time; time.sleep(1.0)
+        import time
+        time.sleep(1.0)
 
         response = requests.get(
-            'http://%s/api/data/%s/_search?q=*' % (self.host,resource_id),
-             )
+            'http://%s/api/data/%s/_search?q=*' % (self.host, resource_id))
 
         response = json.loads(response.content)
-        assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
+        assert_equal(len(response['hits']['hits']), 6)
 
         # Check the number of fields to enusre the lines have been split
         # correctly
         assert len(response['hits']['hits'][0]['_source'].keys()) == 3
-
 
     def test_excel_file(self):
 
@@ -168,20 +162,21 @@ class TestUploadBasic(object):
 
         tasks.datastorer_upload(json.dumps(context), json.dumps(data))
 
-        import time; time.sleep(0.5)
+        import time
+        time.sleep(0.5)
 
         response = requests.get(
-            'http://%s/api/data/%s/_search?q=*' % (self.host,resource_id),
-             )
+            'http://%s/api/data/%s/_search?q=*' % (self.host, resource_id))
 
         response = json.loads(response.content)
 
-        assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
+        assert_equal(len(response['hits']['hits']), 6)
 
     def test_messier_file(self):
 
-        data = {'url': 'http://0.0.0.0:50001/static/3ffdcd42-5c63-4089-84dd-c23876259973',
-                'format': 'csv'}
+        data = {
+            'url': 'http://0.0.0.0:50001/static/3ffdcd42-5c63-4089-84dd-c23876259973',
+            'format': 'csv'}
 
         context = {'site_url': 'http://%s' % self.host,
                    'apikey': self.api_key,
@@ -194,13 +189,11 @@ class TestUploadBasic(object):
         tasks.datastorer_upload(json.dumps(context), json.dumps(data))
 
         response = requests.get(
-            'http://%s/api/data/%s/_search?q=*' % (self.host,resource_id),
-             )
+            'http://%s/api/data/%s/_search?q=*' % (self.host, resource_id))
 
         response = json.loads(response.content)
 
-        assert len(response['hits']['hits']) == 10, len(response['hits']['hits'])
-
+        assert_equal(len(response['hits']['hits']), 10)
 
     def test_error_bad_url(self):
 
@@ -209,11 +202,12 @@ class TestUploadBasic(object):
 
         context = {'site_url': 'http://%s' % self.host,
                    'apikey': self.api_key,
-                   'site_user_apikey': self.api_key,
-                  }
+                   'site_user_apikey': self.api_key}
 
         resource_id = self.make_resource_id()
         data['id'] = resource_id
 
-        assert_raises(LinkCheckerError, tasks.datastorer_upload, json.dumps(context), json.dumps(data))
-
+        assert_raises(LinkCheckerError,
+                      tasks.datastorer_upload,
+                      json.dumps(context),
+                      json.dumps(data))

--- a/ckanext/datastorer/tests/test_upload_basic.py
+++ b/ckanext/datastorer/tests/test_upload_basic.py
@@ -88,6 +88,34 @@ class TestUploadBasic(object):
         assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
 
 
+    def test_tsv_file(self):
+
+        data = {'url': 'http://0.0.0.0:50001/static/simple.tsv',
+                'format': 'tsv',
+                'id': 'uuid3'}
+
+        context = {'site_url': 'http://%s' % self.host,
+                   'site_user_apikey': self.api_key,
+                   'apikey': self.api_key
+                  }
+
+        resource_id = self.make_resource_id()
+        data['id'] = resource_id
+
+        tasks.datastorer_upload(json.dumps(context), json.dumps(data))
+
+        import time; time.sleep(1.0)
+
+        response = requests.get(
+            'http://%s/api/data/%s/_search?q=*' % (self.host,resource_id),
+             )
+
+        response = json.loads(response.content)
+        assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
+
+        # Check the number of fields to enusre the lines have been split
+        # correctly
+        assert len(response['hits']['hits'][0]['_source'].keys()) == 3
 
 
     def test_excel_file(self):

--- a/ckanext/datastorer/tests/test_upload_basic.py
+++ b/ckanext/datastorer/tests/test_upload_basic.py
@@ -85,7 +85,6 @@ class TestUploadBasic(object):
              )
 
         response = json.loads(response.content)
-
         assert len(response['hits']['hits']) == 6, len(response['hits']['hits'])
 
 


### PR DESCRIPTION
Currently messytables (recent update) needs to be told which delimiter to use, and currently it isn't. Have changed the task to use \t as a delimiter for those occasions when it is given text/tsv or text/tab-separated-values. Also fixed a missing url from the resource which master was currently complaining was mandatory.

I can't test this change, and would appreciate if somebody could before merging this change.
