### PR TITLE
Fix path to pip-requirements.txt in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ After activating your pyenv, install the sources via pip::
 
 Install the requirements::
 
-    $ (pyenv) pip install -r ckanext-datastorer/requires.txt
+    $ (pyenv) pip install -r ckanext-datastorer/pip-requirements.txt
 
 Add the datastorer plugin to your configuration ini file::
 


### PR DESCRIPTION
requires.txt was renamed, but the README was not updated.
