### PR TITLE
Various Improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ A paster command is available, that lets you archive all resources or just those
 
 	paster datastorer update [package-id]
 
+To queue the update to run in celery, use:
+
+	paster datastorer queue [package-id]
 
 Developers
 ----------

--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -86,13 +86,15 @@ class Webstorer(CkanCommand):
                 for resource in package.get('resources', []):
                     data = json.dumps(resource, {'model': model})
 
-                    # skip update if the datastore is already active (a table exists)
-                    if resource.get('datastore_active'):
-                        continue
+                    ## skip update if the datastore is already active (a table exists)
+                    #if resource.get('datastore_active'):
+                    #    continue
                     mimetype = resource['mimetype']
                     if mimetype and (mimetype not in tasks.DATA_FORMATS
-                                     or resource['format'] not in
+                                     or resource['format'].lower() not in
                                      tasks.DATA_FORMATS):
+                        logger.warn('Skipping resource %s from package %s because MIME type %s or format %s is unrecognized'
+                              % (resource['url'], package['name'], mimetype, resource['format']))
                         continue
 
                     logger.info('Datastore resource from resource %s from '

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -61,6 +61,17 @@ def check_response_and_retry(response, datastore_request_url):
     except Exception, e:
         datastorer_upload.retry(exc=e)
 
+def log_response(logger, message, resource, response):
+    if response.status_code == 200:
+        logger.info(message.format(res_id=resource['id'], response="Success"))
+    else:
+        err = response.content
+        try:
+            import pprint, json
+            err = "\n" + pprint.pformat(json.loads(response.content)["error"], indent=4, width=40)
+        except:
+            pass
+        logger.error(message.format(res_id=resource['id'], response="Error: Response Code " + str(response.status_code) + ": " + err))
 
 def stringify_processor():
     def to_string(row_set, row):
@@ -144,41 +155,57 @@ def _datastorer_upload(context, resource, logger):
         ],
         strict=True
     )
-    #row_set.register_processor(offset_processor(offset + 1))
     row_set.register_processor(types_processor(guessed_types))
     row_set.register_processor(stringify_processor())
 
     ckan_url = context['site_url'].rstrip('/')
 
-    datastore_request_url = '%s/api/action/datastore_create' % (ckan_url)
+    datastore_request_url = '%s/api/action/datastore_' % (ckan_url)
 
     guessed_type_names = [TYPE_MAPPING[type(gt)] for gt in guessed_types]
 
-    def send_request(data):
-        request = {'resource_id': resource['id'],
-                   'fields': [dict(id=name, type=typename) for name, typename in zip(headers, guessed_type_names)],
-                   'records': data}
-
-        return requests.post(datastore_request_url,
+    def send_request(data, action, logmessage):
+        request = {'resource_id': resource['id'] }
+        if action == "create":
+            request['fields'] = [dict(id=name, type=typename) for name, typename in zip(headers, guessed_type_names)]
+            request['records'] = []
+        if action == "upsert":
+            request['records'] = data
+            request['method'] = 'insert'
+            
+        #import pprint
+        #print datastore_request_url+action
+        #pprint.pprint(request)
+        #print
+            
+        response = requests.post(datastore_request_url+action,
                              data=json.dumps(request),
                              headers={'Content-Type': 'application/json',
                                       'Authorization': context['apikey']},
                              )
+        
+        log_response(logger, logmessage, resource, response)
+        
+        return response
+
+    send_request(None, "delete", "Deleted {res_id}: {response}.")
+    send_request(None, "create", "Created {res_id}: {response}.")
 
     data = []
     count = 0
-    for count, dict_ in enumerate(row_set.dicts()):
+    for dict_ in row_set.dicts():
         data.append(dict(dict_))
-        if (count % 100) == 0:
-            response = send_request(data)
-            check_response_and_retry(response, datastore_request_url)
+        count += 1
+        if len(data) == 100:
+            response = send_request(data, "upsert", "Uploaded to {res_id}: {response}.")
+            check_response_and_retry(response, datastore_request_url + "upsert")
             data[:] = []
 
-    if data:
-        response = send_request(data)
-        check_response_and_retry(response, datastore_request_url + '_mapping')
+    if len(data) > 0:
+        response = send_request(data, "upsert", "Uploaded to {res_id}: {response}.")
+        check_response_and_retry(response, datastore_request_url + "upsert")
 
-    logger.info("There should be {n} entries in {res_id}.".format(n=count + 1, res_id=resource['id']))
+    logger.info("There should be {n} entries in {res_id}.".format(n=count, res_id=resource['id']))
 
     ckan_request_url = ckan_url + '/api/action/resource_update'
 

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -36,7 +36,7 @@ class DateUtilType(messytables.types.CellType):
 
 TYPE_MAPPING = {
     messytables.types.StringType: 'text',
-    messytables.types.IntegerType: 'int',
+    messytables.types.IntegerType: 'numeric', # 'int' may not be big enough, and type detection may not realize it needs to be big
     messytables.types.FloatType: 'float',
     messytables.types.DecimalType: 'numeric',
     messytables.types.DateType: 'timestamp',

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -3,4 +3,4 @@
 celery==2.4.2
 kombu==2.1.3
 kombu-sqlalchemy==1.1.0
-python-dateutil
+python-dateutil<2.0.0


### PR DESCRIPTION
Correct piprequest for python-dateutil version.

Make the update command synchronous (no celery, easier to debug) and add a new 'queue' command that does what update used to do.

A major cleanup to the upload task, mainly doing delete/create/upsert rather than just create and improved logging.

Lots more changes coming if my messytables pull request is accepted.

always use the postgresql 'numeric' type rather than 'int' because we can't be sure the numbers will fit in the range of the pgsql integer
