### PR TITLE
A bunch more patches - must issue datastore_delete, make sure headers are unique, refactor format detection, support ZIP files, improve logging

### DIFF
--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -117,6 +117,7 @@ def _datastorer_upload(context, resource, logger):
     ##only first sheet in xls for time being
     row_set = table_sets.tables[0]
     offset, headers = headers_guess(row_set.sample)
+    headers = headers_make_unique(headers, max_length=62) # truncate to the max column name length postgres seems to like
     row_set.register_processor(headers_processor(headers))
     row_set.register_processor(offset_processor(offset + 1))
     row_set.register_processor(datetime_procesor())

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -156,6 +156,20 @@ def _datastorer_upload(context, resource, logger):
                          )
         check_response_and_retry(response, datastore_create_request_url, logger)
 
+    # Delete any existing data before proceeding. Otherwise 'datastore_create' will
+    # append to the existing datastore. And if the fields have significantly changed,
+    # it may also fail.
+    try:
+        logger.info('Deleting existing datastore (it may not exist): {0}.'.format(resource['id']))
+        response = requests.post('%s/api/action/datastore_delete' % (ckan_url),
+                        data=json.dumps({'resource_id': resource['id'],}),
+                         headers={'Content-Type': 'application/json',
+                                  'Authorization': context['apikey']},
+                         )
+        check_response_and_retry(response, datastore_create_request_url, logger)
+    except:
+        pass
+
     logger.info('Creating: {0}.'.format(resource['id']))
 
     # generates chunks of data that can be loaded into ckan

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -54,8 +54,8 @@ def check_response_and_retry(response, datastore_create_request_url, logger):
 
     if response.status_code not in (201, 200):
         try:
-            # try logging a json response but ignore it if the content is not json
-            logger.info('JSON response was {0}'.format(json.loads(response.content)))
+            # try logging a json response but ignore it if the content is not json or doesn't have an 'error' key.
+            logger.error('JSON response was {0}'.format(json.loads(response.content)["error"]))
         except:
             pass
         raise DatastorerException('Datastorer bad response code (%s) on %s. Response was %s' %


### PR DESCRIPTION
- Must issue datastore_delete: Otherwise subsequent calls to update will append to the existing datastore  (e.g. use case is if the upstream file changed).
- Make sure headers are unique: Postgresql is unhappy if the headers are not unique within the first 63 characters. Calls my new function in messytables.
- Refactor format detection using my changes to messytables.
- Support ZIP files (just mime type check) since I added support in messytables.
- Improve logging.
