### PR TITLE
Add paging to all packages API call

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -31,6 +31,22 @@ class Datastorer(CkanCommand):
     usage = __doc__
     min_args = 1
     max_args = 2
+    MAX_PER_PAGE = 50
+
+    def _get_all_packages(self, api_url, headers):
+        page = 1
+        while True:
+            response = requests.post(api_url +
+                                     '/current_package_list_with_resources',
+                                     '{"page": %d, "limit": %d}' %
+                                     (page, self.MAX_PER_PAGE),
+                                     headers=headers)
+            packages = json.loads(response.content).get('result')
+            if not packages:
+                raise StopIteration
+            for package in packages:
+                yield package
+            page += 1
 
     def command(self):
         """
@@ -62,7 +78,6 @@ class Datastorer(CkanCommand):
             headers = {
                 'content-type:': 'application/json'
             }
-
             if len(self.args) == 2:
                 response = requests.post(api_url +
                                          '/package_show',
@@ -75,12 +90,8 @@ class Datastorer(CkanCommand):
                 else:
                     logger.error('Error getting dataset %s' % self.args[1])
                     sys.exit(1)
-
             else:
-                response = requests.post(api_url +
-                                         '/current_package_list_with_resources',
-                                         "{}", headers=headers)
-                packages = json.loads(response.content).get('result')
+                packages = self._get_all_packages(api_url, headers)
 
             for package in packages:
                 for resource in package.get('resources', []):


### PR DESCRIPTION
A server timeout is very likely for the current_package_list_with_resources API call that gets all packages with no paging.

This introduces paging with a limit of 50 packages per page. And it's wrapped in a neat generator.
