### PR TITLE
Check modified date and hash in datastore_upload

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -256,21 +256,22 @@ class AddToDataStore(CkanCommand):
             logger.info(
                 'Skipping unmodified resource: {0}'.format(resource['url'])
             )
-            return
+            return {'success': True,
+                    'resource': resource['id'],
+                    'error': None}
         except Exception as e:
             logger.exception(e)
-            status = {
-                'success': False,
-                'resource': resource['id'],
-                'error': 'Could not download resource',
-            }
-            return status
+            return {'success': False,
+                    'resource': resource['id'],
+                    'error': 'Could not download resource'}
 
         if result['hash'] == original_hash:
             logger.info(
                 'Skipping unmodified resource: {0}'.format(resource['url'])
             )
-            return
+            return {'success': True,
+                    'resource': resource['id'],
+                    'error': None}
 
         content_type = result['headers'].get('content-type', '')\
                                         .split(';', 1)[0]  # remove parameters
@@ -284,12 +285,9 @@ class AddToDataStore(CkanCommand):
             )
         except Exception as e:
             logger.exception(e)
-            status = {
-                'success': False,
-                'resource': resource['id'],
-                'error': 'Error parsing the resource',
-            }
-            return status
+            return {'success': False,
+                    'resource': resource['id'],
+                    'error': 'Error parsing the resource'}
 
         # only first sheet in xls for time being
         row_set = table_sets.tables[0]
@@ -368,12 +366,9 @@ class AddToDataStore(CkanCommand):
                 send_request(data)
         except Exception as e:
             logger.exception(e)
-            status = {
-                'success': False,
-                'resource': resource['id'],
-                'error': 'Error pushing data to datastore',
-            }
-            return status
+            return {'success': False,
+                    'resource': resource['id'],
+                    'error': 'Error pushing data to datastore'}
 
         logger.info("There should be {n} entries in {res_id}.".format(
             n=count,
@@ -386,12 +381,9 @@ class AddToDataStore(CkanCommand):
         })
 
         toolkit.get_action('resource_update')(context, resource)
-        status = {
-            'success': True,
-            'resource': resource['id'],
-            'error': None,
-        }
-        return status
+        return {'success': True,
+                'resource': resource['id'],
+                'error': None}
 
 
 def stringify_processor():

--- a/ckanext/datastorer/tests/tests_config.cfg
+++ b/ckanext/datastorer/tests/tests_config.cfg
@@ -1,5 +1,5 @@
 [tests]
 # CKAN instance host
-ckan_host=127.0.0.1:5001
+ckan_host=0.0.0.0:5000
 # CKAN User API key (Must be a sysadmin)
-user_api_key=5eaff122-b2ce-4a89-87ad-2c6139cba570
+user_api_key=moo

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -3,3 +3,4 @@
 celery==2.4.2
 kombu==2.1.3
 kombu-sqlalchemy==1.1.0
+python-dateutil>=1.5


### PR DESCRIPTION
The datastore_upload command should try to avoid downloading and datastoring resources unless they have changed. It could:
- do a HEAD request and (if accepted) see if there is a last-modified header, check that it is more recent than the resource's last modified date
- after downloading check to see if the hash has changed before datastoring
