### PR TITLE
[#39] Don't use from_fileobj because it is removed from messytables 0.8

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import itertools
 import json
 import messytables
-from messytables import (AnyTableSet, types_processor, headers_guess,
+from messytables import (any_tableset, types_processor, headers_guess,
                          headers_processor, type_guess, offset_processor)
 import requests
 import urlparse
@@ -278,7 +278,7 @@ class AddToDataStore(CkanCommand):
 
         f = open(result['saved_file'], 'rb')
         try:
-            table_sets = AnyTableSet.from_fileobj(
+            table_sets = any_tableset(
                 f,
                 mimetype=content_type,
                 extension=resource['format'].lower()

--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -6,7 +6,7 @@ import itertools
 import locale
 
 import messytables
-from messytables import (AnyTableSet, types_processor,
+from messytables import (any_tableset, types_processor,
                          headers_guess, headers_processor, headers_make_unique,
                          type_guess, offset_processor)
 from ckanext.archiver.tasks import download, update_task_status
@@ -98,7 +98,7 @@ def _datastorer_upload(context, resource, logger):
                                     .split(';', 1)[0]  # remove parameters
 
     f = open(result['saved_file'], 'rb')
-    table_sets = AnyTableSet.from_fileobj(f, mimetype=content_type, extension=resource['format'].lower())
+    table_sets = any_tableset(f, mimetype=content_type, extension=resource['format'].lower())
 
     ##only first sheet in xls for time being
     row_set = table_sets.tables[0]

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,4 +1,4 @@
-messytables==0.7
+messytables==0.8
 -e git+https://github.com/okfn/ckanext-archiver.git#egg=ckanext-archiver
 celery==2.4.2
 kombu==2.1.3


### PR DESCRIPTION
Fixes #39 
