### PR TITLE
[#46] Remove the tempfile created by the command

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -5,6 +5,7 @@ import json
 import messytables
 from messytables import (any_tableset, types_processor, headers_guess,
                          headers_processor, type_guess, offset_processor)
+import os
 import requests
 import urlparse
 from pylons import config
@@ -293,6 +294,7 @@ class AddToDataStore(CkanCommand):
             )
         except Exception as e:
             logger.exception(e)
+            os.remove(result['saved_file'])
             return {'success': False,
                     'resource': resource['id'],
                     'error': 'Error parsing the resource'}
@@ -374,6 +376,7 @@ class AddToDataStore(CkanCommand):
                 send_request(data)
         except Exception as e:
             logger.exception(e)
+            os.remove(result['saved_file'])
             return {'success': False,
                     'resource': resource['id'],
                     'error': 'Error pushing data to datastore'}
@@ -389,6 +392,7 @@ class AddToDataStore(CkanCommand):
         })
 
         toolkit.get_action('resource_update')(context, resource)
+        os.remove(result['saved_file'])
         return {'success': True,
                 'resource': resource['id'],
                 'error': None}

--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -265,11 +265,13 @@ class AddToDataStore(CkanCommand):
             logger.info(
                 'Skipping unmodified resource: {0}'.format(resource['url'])
             )
+            os.remove(result['saved_file'])
             return {'success': True,
                     'resource': resource['id'],
                     'error': None}
         except Exception as e:
             logger.exception(e)
+            os.remove(result['saved_file'])
             return {'success': False,
                     'resource': resource['id'],
                     'error': 'Could not download resource'}
@@ -278,6 +280,7 @@ class AddToDataStore(CkanCommand):
             logger.info(
                 'Skipping unmodified resource: {0}'.format(resource['url'])
             )
+            os.remove(result['saved_file'])
             return {'success': True,
                     'resource': resource['id'],
                     'error': None}


### PR DESCRIPTION
Add `os.remove` commands to remove the temporary file created by the cron command. Fixes #46.
