### PR TITLE
encode resource['url'] as unicode when logging

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -115,15 +115,14 @@ class Datastorer(CkanCommand):
                     if mimetype and not(mimetype in tasks.DATA_FORMATS or
                                         resource['format'].lower() in
                                         tasks.DATA_FORMATS):
-                        logger.warn('Skipping resource %s from package %s '
-                                'because MIME type %s and format %s are '
-                                'unrecognized' % (resource['url'].encode('utf-8'),
+                        logger.warn(u'Skipping resource %s from package %s '
+                                u'because MIME type %s and format %s are '
+                                u'unrecognized' % (resource['url'],
                                 package['name'], mimetype, resource['format']))
                         continue
 
-                    logger.info('Datastore resource from resource %s from '
-                                'package %s' % (resource['url'].encode('utf-8'),
-                                                package['name']))
+                    logger.info(u'Datastore resource from resource %s from '
+                                u'package %s' % (resource['url'], package['name']))
 
                     if cmd == "update":
                         logger.setLevel(0)
@@ -228,9 +227,9 @@ class AddToDataStore(CkanCommand):
                 if mimetype and not(mimetype in DATA_FORMATS or
                                     resource['format'].lower()
                                     in DATA_FORMATS):
-                    logger.warn('Skipping resource {0} from package {1} '
-                        'because MIME type {2} and format {3} is '
-                        'unrecognized'.format(resource['url'].encode('utf-8'),
+                    logger.warn(u'Skipping resource {0} from package {1} '
+                        u'because MIME type {2} and format {3} is '
+                        u'unrecognized'.format(resource['url'],
                                               package['name'],
                                               mimetype,
                                               resource['format']))
@@ -239,8 +238,8 @@ class AddToDataStore(CkanCommand):
                         self.options.ignore):
                     logger.warn('Ignoring resource {0}'.format(resource['id']))
                     continue
-                logger.info('Datastore resource from resource {0} from '
-                    'package {0}'.format(resource['url'].encode('utf-8'),
+                logger.info(u'Datastore resource from resource {0} from '
+                    u'package {0}'.format(resource['url'],
                                          package['name']))
                 status = self.push_to_datastore(context, resource)
                 if status['success'] is False:
@@ -263,8 +262,7 @@ class AddToDataStore(CkanCommand):
                                              check_modified=check_hash)
         except fetch_resource.ResourceNotModified as e:
             logger.info(
-                'Skipping unmodified resource: {0}'.format(
-                    resource['url'].encode('utf-8'))
+                u'Skipping unmodified resource: {0}'.format(resource['url'])
             )
             return {'success': True,
                     'resource': resource['id'],
@@ -277,8 +275,7 @@ class AddToDataStore(CkanCommand):
 
         if check_hash and (result['hash'] == original_content_hash):
             logger.info(
-                'Skipping unmodified resource: {0}'.format(
-                    resource['url'].encode('utf-8'))
+                u'Skipping unmodified resource: {0}'.format(resource['url'])
             )
             os.remove(result['saved_file'])
             return {'success': True,

--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -117,12 +117,12 @@ class Datastorer(CkanCommand):
                                         tasks.DATA_FORMATS):
                         logger.warn('Skipping resource %s from package %s '
                                 'because MIME type %s and format %s are '
-                                'unrecognized' % (resource['url'],
+                                'unrecognized' % (resource['url'].encode('utf-8'),
                                 package['name'], mimetype, resource['format']))
                         continue
 
                     logger.info('Datastore resource from resource %s from '
-                                'package %s' % (resource['url'],
+                                'package %s' % (resource['url'].encode('utf-8'),
                                                 package['name']))
 
                     if cmd == "update":
@@ -229,19 +229,19 @@ class AddToDataStore(CkanCommand):
                                     resource['format'].lower()
                                     in DATA_FORMATS):
                     logger.warn('Skipping resource {0} from package {1} '
-                                'because MIME type {2} and format {3} is '
-                                'unrecognized'.format(resource['url'],
-                                                      package['name'],
-                                                      mimetype,
-                                                      resource['format']))
+                        'because MIME type {2} and format {3} is '
+                        'unrecognized'.format(resource['url'].encode('utf-8'),
+                                              package['name'],
+                                              mimetype,
+                                              resource['format']))
                     continue
                 if (self.options.ignore and resource['id'] in
                         self.options.ignore):
                     logger.warn('Ignoring resource {0}'.format(resource['id']))
                     continue
                 logger.info('Datastore resource from resource {0} from '
-                            'package {0}'.format(resource['url'],
-                                                 package['name']))
+                    'package {0}'.format(resource['url'].encode('utf-8'),
+                                         package['name']))
                 status = self.push_to_datastore(context, resource)
                 if status['success'] is False:
                     resource_status.append(status)
@@ -263,7 +263,8 @@ class AddToDataStore(CkanCommand):
                                              check_modified=check_hash)
         except fetch_resource.ResourceNotModified as e:
             logger.info(
-                'Skipping unmodified resource: {0}'.format(resource['url'])
+                'Skipping unmodified resource: {0}'.format(
+                    resource['url'].encode('utf-8'))
             )
             return {'success': True,
                     'resource': resource['id'],
@@ -276,7 +277,8 @@ class AddToDataStore(CkanCommand):
 
         if check_hash and (result['hash'] == original_content_hash):
             logger.info(
-                'Skipping unmodified resource: {0}'.format(resource['url'])
+                'Skipping unmodified resource: {0}'.format(
+                    resource['url'].encode('utf-8'))
             )
             os.remove(result['saved_file'])
             return {'success': True,


### PR DESCRIPTION
if the resource url contains non ascii characters the datastore will fail with UnicodeValueError when attempting to write to the log
