### PR TITLE
[#53] datastore_upload don't check hash for new files

### DIFF
--- a/ckanext/datastorer/commands.py
+++ b/ckanext/datastorer/commands.py
@@ -250,9 +250,10 @@ class AddToDataStore(CkanCommand):
         try:
             original_hash = json.loads(resource.get('hash'))
             original_content_hash = original_hash['content']
+            check_hash = not self.options.force
         except ValueError:
             original_content_hash = resource.get('hash')
-        check_hash = not self.options.force
+            check_hash = False
 
         try:
             result = fetch_resource.download(context,


### PR DESCRIPTION
datastore_upload was skipping new resource files because their hash
wasn't changed, so the files would never be datastored. Fix by not
checking the hash for new files. Fixes #53.
