### PR TITLE
Add a configurable sample size (window) for tables

### DIFF
--- a/ckanext/datastorer/tasks.py
+++ b/ckanext/datastorer/tasks.py
@@ -99,6 +99,10 @@ def _datastorer_upload(context, resource, logger):
 
     f = open(result['saved_file'], 'rb')
     table_sets = any_tableset(f, mimetype=content_type, extension=resource['format'].lower())
+    
+    if 'sample_size' in context:
+        table_sets.window = max(1000, int(context['sample_size']))
+        logger.info('Using a sample window of %d', table_sets.window)
 
     ##only first sheet in xls for time being
     row_set = table_sets.tables[0]


### PR DESCRIPTION
As can be easily observed (e.g. https://github.com/okfn/messytables/blob/master/messytables/commas.py#L123), messytables has a default size of 1000 for the sample of rows used for guessing headers and column types. 

This may be not adequate for certain cases (e.g  too many rows, values for a column not evenly distributed etc), so i added a simple config option `ckanext.datastorer.sample_size` to explicitly set the size of the sample. Since all processing happens in the background, i think is an acceptable cost to wait a bit longer in order have more reliable guesses (if you provide a bigger sample size),
